### PR TITLE
fix(auth): replace several default api

### DIFF
--- a/115_open.go
+++ b/115_open.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/twoonefour/115-sdk-go"
+	"github.com/twoonefour/alist-auth/utils"
+	"net/http"
+)
+
+var (
+	clientID string
+)
+
+type TokenReq struct {
+	Uid          string `json:"uid" binding:"required"`
+	CodeVerifier string `json:"code_verifier" binding:"required"`
+}
+
+func Open115Qrcode(c *gin.Context) {
+	client := sdk.New()
+	var cv string
+	var resp *sdk.AuthDeviceCodeResp
+	cv, err := utils.GenerateCodeVerifier(64)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	resp, err = client.AuthDeviceCode(c, clientID, cv)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"code_verifier": cv,
+		"resp":          resp,
+	})
+}
+
+func Open115Token(c *gin.Context) {
+	client := sdk.New()
+	var req TokenReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	var codeToTokenResp *sdk.CodeToTokenResp
+	codeToTokenResp, err := client.CodeToToken(c, req.Uid, req.CodeVerifier)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"resp": codeToTokenResp})
+}

--- a/ali.go
+++ b/ali.go
@@ -1,9 +1,9 @@
-package alist
+package auth
 
 import (
-	"api.nn.ci/apps/common"
-	"api.nn.ci/utils"
 	"github.com/gin-gonic/gin"
+	"github.com/twoonefour/alist-auth/common"
+	"github.com/twoonefour/alist-auth/utils"
 )
 
 func Qr(c *gin.Context) {
@@ -64,9 +64,9 @@ func Ck(c *gin.Context) {
 			"referer": "https://passport.aliyundrive.com/mini_login.htm?&appName=aliyun_drive",
 		}).
 		Post("https://passport.aliyundrive.com/newlogin/qrcode/query.do?appName=aliyun_drive&fromSite=52&_bx-v=2.0.31")
-	//data := utils.Json.Get(res.Body(), "content", "data")
-	//loginResult := data.Get("loginResult").ToString()
-	//bizExt := data.Get("bizExt").ToString()
+	// data := utils.Json.Get(res.Body(), "content", "data")
+	// loginResult := data.Get("loginResult").ToString()
+	// bizExt := data.Get("bizExt").ToString()
 	c.Header("Content-Type", "application/json")
 	c.Writer.Write(res.Body())
 }

--- a/ali_open.go
+++ b/ali_open.go
@@ -1,11 +1,11 @@
-package alist
+package auth
 
 import (
 	"fmt"
+	"github.com/twoonefour/alist-auth/common"
+	"github.com/twoonefour/alist-auth/utils"
 	"strings"
 
-	"api.nn.ci/apps/common"
-	"api.nn.ci/utils"
 	"github.com/gin-gonic/gin"
 )
 

--- a/baidu.go
+++ b/baidu.go
@@ -1,17 +1,17 @@
-package alist
+package auth
 
 import (
 	"fmt"
+	"github.com/twoonefour/alist-auth/common"
+	"github.com/twoonefour/alist-auth/utils"
 
-	"api.nn.ci/apps/common"
-	"api.nn.ci/utils"
 	"github.com/gin-gonic/gin"
 )
 
 var (
 	baiduClientId     string
 	baiduClientSecret string
-	baiduCallbackUri  = "https://alist.nn.ci/tool/baidu/callback"
+	baiduCallbackUri  = FrontEndBaseUrl + "/tool/baidu/callback"
 )
 
 func baiduToken(c *gin.Context) {

--- a/common/error.go
+++ b/common/error.go
@@ -1,0 +1,41 @@
+package common
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"log"
+)
+
+type Response struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+func Error(c *gin.Context, err error) {
+	log.Printf("[ERROR] %v\n", err)
+	c.AbortWithStatusJSON(http.StatusInternalServerError, Response{
+		Code:    http.StatusInternalServerError,
+		Message: err.Error(),
+	})
+}
+
+func ErrorStr(c *gin.Context, message string) {
+	c.AbortWithStatusJSON(http.StatusInternalServerError, Response{
+		Code:    http.StatusInternalServerError,
+		Message: message,
+	})
+}
+
+func ErrorJson(c *gin.Context, err interface{}, code ...int) {
+	c.AbortWithStatusJSON(http.StatusInternalServerError, Response{
+		Code: func() int {
+			if len(code) > 0 {
+				return code[0]
+			}
+			return http.StatusInternalServerError
+		}(),
+		Data: err,
+	})
+}

--- a/common/json.go
+++ b/common/json.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func JsonBytes(c *gin.Context, jsonBytes []byte) error {
+	c.Header("Content-Type", "application/json; charset=utf-8")
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.Header("Access-Control-Allow-Methods", "POST, OPTIONS")
+	c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	c.Writer.WriteHeaderNow()
+	if _, err := c.Writer.Write(jsonBytes); err != nil {
+		return err
+	}
+	return nil
+}

--- a/onedrive.go
+++ b/onedrive.go
@@ -1,13 +1,17 @@
-package alist
+package auth
 
 import (
 	"encoding/base64"
+	"github.com/twoonefour/alist-auth/common"
 	"net/url"
 	"strings"
 
-	"api.nn.ci/apps/common"
-	"api.nn.ci/utils"
 	"github.com/gin-gonic/gin"
+	"github.com/twoonefour/alist-auth/utils"
+)
+
+var (
+	oneDriveCallBackUri = FrontEndBaseUrl + "/tool/onedrive/callback"
 )
 
 type Zone struct {
@@ -61,7 +65,7 @@ func onedriveToken(c *gin.Context) {
 				"client_secret": clients[1],
 				"code":          req.Code,
 				"grant_type":    "authorization_code",
-				"redirect_uri":  "https://alist.nn.ci/tool/onedrive/callback",
+				"redirect_uri":  oneDriveCallBackUri,
 			}).
 			Post(zone.Oauth + "/common/oauth2/v2.0/token")
 		if err != nil {

--- a/setup.go
+++ b/setup.go
@@ -1,4 +1,4 @@
-package alist
+package auth
 
 import (
 	"os"
@@ -7,6 +7,10 @@ import (
 
 	"github.com/axiaoxin-com/ratelimiter"
 	"github.com/gin-gonic/gin"
+)
+
+var (
+	FrontEndBaseUrl string
 )
 
 func initVar() {
@@ -27,6 +31,7 @@ func initVar() {
 	aliClientSecret = os.Getenv("ALI_DRIVE_CLIENT_SECRET")
 	baiduClientId = os.Getenv("BAIDU_CLIENT_ID")
 	baiduClientSecret = os.Getenv("BAIDU_CLIENT_SECRET")
+	FrontEndBaseUrl = os.Getenv("APIBase")
 }
 
 func Setup(g *gin.RouterGroup) {
@@ -34,8 +39,17 @@ func Setup(g *gin.RouterGroup) {
 	g.GET("/ali/qr", Qr)
 	g.POST("/ali/ck", Ck)
 	g.POST("/onedrive/get_refresh_token", onedriveToken)
+	// CORS should be settle by caddy, nginx or other reverse proxy middleware
+	// g.OPTIONS("/onedrive/get_refresh_token", func(ctx *gin.Context) {
+	// 	ctx.Header("Access-Control-Allow-Origin", "*")
+	// 	ctx.Header("Access-Control-Allow-Methods", "POST, OPTIONS")
+	// 	ctx.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	// 	ctx.Status(204)
+	// })
 	g.POST("/onedrive/get_site_id", spSiteID)
 	g.GET("/baidu/get_refresh_token", baiduToken)
+	g.GET("/115/auth_device_code", Open115Qrcode)
+	g.POST("/115/get_token", Open115Token)
 	aliOpen := g.Group("/ali_open")
 	aliOpen.Any("/limit", func(ctx *gin.Context) {
 		ctx.JSON(200, gin.H{

--- a/utils/client.go
+++ b/utils/client.go
@@ -1,0 +1,9 @@
+package utils
+
+import (
+	"github.com/go-resty/resty/v2"
+)
+
+var (
+	RestyClient = resty.New()
+)

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,0 +1,35 @@
+// Package utils utils/log.go
+package utils
+
+import (
+	"github.com/gin-gonic/gin"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func LoggerMiddleware() gin.HandlerFunc {
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339,
+	})
+	logrus.SetLevel(logrus.InfoLevel)
+
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+		duration := time.Since(start)
+		entry := logrus.WithFields(logrus.Fields{
+			"status":     c.Writer.Status(),
+			"method":     c.Request.Method,
+			"path":       c.Request.URL.Path,
+			"client_ip":  c.ClientIP(),
+			"user_agent": c.Request.UserAgent(),
+			"duration":   duration.Seconds(),
+		})
+
+		if len(c.Errors) > 0 {
+			entry.Error(c.Errors.String())
+		}
+
+	}
+}

--- a/utils/pkce.go
+++ b/utils/pkce.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+)
+
+func GenerateCodeVerifier(n int) (string, error) {
+	// generate CodeVerifier for 115Open
+	if n < 43 || n > 128 {
+		return "", errors.New("code_verifier length must be between 43 and 128")
+	}
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	s := base64.RawURLEncoding.EncodeToString(buf)
+	return s[:n], nil
+}


### PR DESCRIPTION
* fix(onedrive): replace api base
* feat(115_open): 115_open oauth implement
* feat(main): add main entry as backend app

隔壁直接弃用了原来的go后端oauth2，用的cf worker api，我们这边直接沿用xhofe原来的api认证吧
